### PR TITLE
Shebang: do not hardcode path to bash

### DIFF
--- a/bacula-zabbix.sh
+++ b/bacula-zabbix.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Import configuration file
 source /etc/bacula/bacula-zabbix.conf


### PR DESCRIPTION
this is for compatibility reasons because not all unix distributions
keep their bash at /bin