### PR TITLE
allow config path to be overwritten by environment

### DIFF
--- a/bacula-zabbix.sh
+++ b/bacula-zabbix.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # Import configuration file
-source /etc/bacula/bacula-zabbix.conf
+source ${BACULA_ZABBIX_CONFIG:-/etc/bacula/bacula-zabbix.conf}
 
 # Get Job ID from parameter
 baculaJobId="$1"


### PR DESCRIPTION
A environment variable BACULA_ZABBIX_CONFIG may control the path to the
configuration file if set.