### PR TITLE
allow transformation of Client.Name

### DIFF
--- a/bacula-zabbix.conf
+++ b/bacula-zabbix.conf
@@ -30,3 +30,7 @@ zabbixSrvPort='10051'
 
 # Path to zabbix_sender command
 zabbixSender='/usr/bin/zabbix_sender'
+
+# configure client name mapping
+# clientName="replace(Client.Name, 'foo', 'bar') as Name"
+clientName='Client.Name'

--- a/bacula-zabbix.sh
+++ b/bacula-zabbix.sh
@@ -3,6 +3,8 @@
 # Import configuration file
 source /etc/bacula/bacula-zabbix.conf
 
+clientName=${clientName:-Client.Name}
+
 # Get Job ID from parameter
 baculaJobId="$1"
 if [ -z $baculaJobId ] ; then exit 3 ; fi
@@ -40,7 +42,7 @@ case $baculaJobStatus in
 esac
 
 # Get client's name from database
-baculaClientName=$($sql "select Client.Name from Client,Job where Job.ClientId=Client.ClientId and Job.JobId=$baculaJobId;" 2>/dev/null)
+baculaClientName=$($sql "select $clientName from Client,Job where Job.ClientId=Client.ClientId and Job.JobId=$baculaJobId;" 2>/dev/null)
 if [ -z $baculaClientName ] ; then exit 15 ; fi
 
 # Initialize return as zero


### PR DESCRIPTION
if your bacula clients are not exactly named like zabbix hosts, this
transformation can be used to map between them in sql